### PR TITLE
Fix ISOCodes magic methods phpdocs

### DIFF
--- a/src/ISOCodes.php
+++ b/src/ISOCodes.php
@@ -11,11 +11,11 @@ use Juanparati\ISOCodes\Exceptions\ISOModelNotFound;
 /**
  * Provide the main ISOCodes objects.
  *
- * @method \Juanparati\ISOCodes\Models\ContinentModel continents
- * @method \Juanparati\ISOCodes\Models\CountryModel countries
- * @method \Juanparati\ISOCodes\Models\CurrencyModel currencies
- * @method \Juanparati\ISOCodes\Models\CurrencyNumberModel currencyNumbers
- * @method \Juanparati\ISOCodes\Models\LanguageModel languages
+ * @method \Juanparati\ISOCodes\Models\ContinentModel continents()
+ * @method \Juanparati\ISOCodes\Models\CountryModel countries()
+ * @method \Juanparati\ISOCodes\Models\CurrencyModel currencies()
+ * @method \Juanparati\ISOCodes\Models\CurrencyNumberModel currencyNumbers()
+ * @method \Juanparati\ISOCodes\Models\LanguageModel languages()
  */
 class ISOCodes
 {


### PR DESCRIPTION
If you don't put the parenthesis, they are not recognized as valid by phpstan.

```
  :14    PHPDoc tag @method has invalid value (\Juanparati\ISOCodes\Models\ContinentModel  
         continents): Unexpected token "\n * ", expected '(' at offset 109                 
  :14    PHPDoc tag @method has invalid value (\Juanparati\ISOCodes\Models\CountryModel    
         countries): Unexpected token "\n * ", expected '(' at offset 171                  
  :14    PHPDoc tag @method has invalid value (\Juanparati\ISOCodes\Models\CurrencyModel   
         currencies): Unexpected token "\n * ", expected '(' at offset 235                 
  :14    PHPDoc tag @method has invalid value                                              
         (\Juanparati\ISOCodes\Models\CurrencyNumberModel currencyNumbers): Unexpected     
         token "\n * ", expected '(' at offset 310                                         
  :14    PHPDoc tag @method has invalid value (\Juanparati\ISOCodes\Models\LanguageModel   
         languages): Unexpected token "\n ", expected '(' at offset 373
```